### PR TITLE
Fix gcc build

### DIFF
--- a/src/dep/include/zthread/Guard.h
+++ b/src/dep/include/zthread/Guard.h
@@ -428,7 +428,7 @@ public:
   template <class U, class V>
   Guard(Guard<U, V>& g) : LockHolder<LockType>(g) {
 
-    LockingPolicy::shareScope(*this, extract(g));
+    LockingPolicy::shareScope(*this, this->extract(g));
 
   }
 


### PR DESCRIPTION
Note to linux users:
If it doesn't link with X11, do this:
cmake .. -DCMAKE_CXX_FLAGS:STRING=-lX11
